### PR TITLE
Generate logrotate config for ftw.structlog's logfiles.

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -1,10 +1,11 @@
 Changelog
 =========
 
-1.2.1 (unreleased)
+1.3.0 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Generate logrotate config for ftw.structlog's logfiles.
+  [lgraf]
 
 
 1.2.0 (2016-02-10)

--- a/README.rst
+++ b/README.rst
@@ -8,7 +8,8 @@ deploying Plone/Zope2 with buildout.
 
 As for now the following features are provided:
 
-* Create Logrotate configuration for all Zope 2 instance and ZEO parts.
+* Create Logrotate configuration for all Zope 2 instance and ZEO parts,
+  as well as ``ftw.structlog`` logfiles.
 
 * Create RedHat-like run-control scripts.
 
@@ -25,6 +26,10 @@ logrotate-directory
     Defaults to ``${buildout:directory}/etc/logrotate.d``. Add this parameter
     with no arguments to supress generation of logrotate configuration.
 
+    If this parameter is set, this recipe will create logrotate configs for
+    all Zope 2 instance and ZEO parts that are present, and (unconditionally)
+    a logrotate config for ``ftw.structlog`` logfiles.
+
 logrotate-options
     A list of logrotate options that should be added to the logrotate
     configuration.
@@ -40,6 +45,15 @@ logrotate-options
          missingok
          notifempty
          nomail
+
+    The logrotate config for ``ftw.structlog`` logfiles will be created with
+    settings similar to the other logfiles, except:
+
+    * No ``postrotate`` script will be automatically inserted if not already
+      present in ``logrotate-options``
+    * ``missingok`` will always be included
+    * Rotation mode will always be ``copytruncate``, and ``nocopytruncate``
+      will be ignored
 
 startup-directory
     If specified, a start script is created in the given directory.

--- a/ftw/recipe/deployment/README.txt
+++ b/ftw/recipe/deployment/README.txt
@@ -87,6 +87,10 @@ containing our logrotate configuration::
             /bin/kill -SIGUSR2 `cat /sample-buildout/var/instance1.pid 2>/dev/null` >/dev/null 2>&1 || true
         endscript
     }
+    /sample-buildout/var/log/instance1-json.log {
+        copytruncate
+        missingok
+    }
 
 We should also have a run-control script for instance1::
 
@@ -223,6 +227,14 @@ Verify the contents of the logrotate configuration file::
     }
     /sample-buildout/var/log/zeo.log {
         copytruncate
+    }
+    /sample-buildout/var/log/instance1-json.log {
+        copytruncate
+        missingok
+    }
+    /sample-buildout/var/log/instance2-json.log {
+        copytruncate
+        missingok
     }
 
 Verify the zeo run control script::
@@ -596,6 +608,14 @@ Verify that the file contains our logrotate options::
         postrotate
             /bin/kill -SIGUSR2 `cat /sample-buildout/var/instance1.pid 2>/dev/null` >/dev/null 2>&1 || true
         endscript
+    }
+    /sample-buildout/var/log/instance1-json.log {
+        rotate 4
+        weekly
+        missingok
+        notifempty
+        nomail
+        copytruncate
     }
 
 We can provide custom storage options::

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '1.2.1.dev0'
+version = '1.3.0.dev0'
 tests_require = ['zc.buildout [test]']
 
 setup(name='ftw.recipe.deployment',


### PR DESCRIPTION
With this change, `ftw.recipe.deployment` will always **generate logrotation configs for `ftw.structlog` logfiles**
*(unless log rotation config generation is disabled alltogether by setting `logrotate-directory` to the empty string).*

---

The logrotate config for `ftw.structlog` logfiles will honour `logrotate-options` as well, and so be created with settings similar to the other logfiles, except:

- No `postrotate` script will be automatically inserted if not already present in `logrotate-options`
- ``missingok`` will always be included
- Rotation mode will always be `copytruncate`, and `nocopytruncate` will be ignored