### PR TITLE
Generate filebeat prospector configs for ftw.structlog and ftw.contentstats logs

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,9 @@ Changelog
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Generate filebeat prospector configs for ftw.structlog and
+  ftw.contentstats logs.
+  [lgraf]
 
 
 1.3.0 (2017-09-11)

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,9 @@ As for now the following features are provided:
 
 * Create packall script for packing of all storages.
 
+* Create filebeat prospector configs for ``ftw.structlog`` and
+  ``ftw.contentstats`` logs.
+
 
 Supported options
 =================

--- a/ftw/recipe/deployment/README.txt
+++ b/ftw/recipe/deployment/README.txt
@@ -140,6 +140,29 @@ We should also have a run-control script for instance1::
             ;;
     esac
 
+We should also have a filebeat prospectors config for your deployment::
+
+    >>> cat(sample_buildout, 'etc', 'filebeat.d', 'sample-buildout.yml')
+    ... #doctest: -NORMALIZE_WHITESPACE
+    - type: log
+      fields:
+        event_type: contentstats
+        deployment: sample-buildout
+      fields_under_root: true
+      json.keys_under_root: true
+      json.add_error_key: true
+      paths:
+        - /sample-buildout/var/log/contentstats-json.log
+    - type: log
+      fields:
+        event_type: structlog
+        deployment: sample-buildout
+      fields_under_root: true
+      json.keys_under_root: true
+      json.add_error_key: true
+      paths:
+        - /sample-buildout/var/log/instance1-json.log
+
 Let's also add a zeo part. Thus we first need a fake ``plone.recipe.zeoserver``
 recipe::
 

--- a/ftw/recipe/deployment/__init__.py
+++ b/ftw/recipe/deployment/__init__.py
@@ -1,9 +1,10 @@
 # -*- coding: utf-8 -*-
 """Recipe deployment"""
 import os.path
+from ftw.recipe.deployment.filebeat import create_filebeat_conf
 from ftw.recipe.deployment.logrotate import create_logrotate_conf
-from ftw.recipe.deployment.rc import create_rc_scripts
 from ftw.recipe.deployment.pack import create_pack_script
+from ftw.recipe.deployment.rc import create_rc_scripts
 
 
 class Recipe(object):
@@ -65,6 +66,11 @@ class Recipe(object):
         logrotate_conf = create_logrotate_conf(self)
         if logrotate_conf:
             files.append(logrotate_conf)
+
+        # Create filebeat configuration
+        filebeat_conf = create_filebeat_conf(self)
+        if filebeat_conf:
+            files.append(filebeat_conf)
 
         rc_scripts = create_rc_scripts(self)
         files.extend(rc_scripts)

--- a/ftw/recipe/deployment/filebeat.py
+++ b/ftw/recipe/deployment/filebeat.py
@@ -1,0 +1,56 @@
+import os
+import os.path
+
+PROSPECTOR_TEMPLATE = """\
+- type: log
+  fields:
+    event_type: %s
+    deployment: %s
+  fields_under_root: true
+  json.keys_under_root: true
+  json.add_error_key: true
+  paths:
+    - %s\
+"""
+
+
+def create_filebeat_conf(recipe):
+    """Create a filebeat prospectors config file and return the filename of
+    the created file.
+    """
+    default_etc_dir = os.path.join(recipe.buildout_dir, 'etc')
+    etc_dir = recipe.options.get('etc-directory', default_etc_dir)
+
+    filebeat_dir = os.path.join(etc_dir, 'filebeat.d')
+
+    # Try to create the filebeat config directory
+    if not os.path.isdir(filebeat_dir):
+        try:
+            os.makedirs(filebeat_dir)
+        except OSError:
+            return None
+
+    # Create contentstats prospector (one per deployment)
+    contentstats_log = os.path.join(
+        recipe.buildout_dir, 'var/log/contentstats-json.log')
+    contentstats_prospector = PROSPECTOR_TEMPLATE % (
+        'contentstats', recipe.buildout_name, contentstats_log)
+
+    # Add configuration for ftw.structlog logs (one per instance)
+    prospectors = [contentstats_prospector]
+    for zope_part in recipe.zope_parts:
+        event_log = '%s/var/log/%s.log' % (recipe.buildout_dir, zope_part)
+        event_log = recipe.buildout[zope_part].get('event-log', event_log)
+        # ftw.structlog's log path is based on eventlog path
+        structlog_json_log = event_log.replace('.log', '-json.log')
+
+        structlog_prospector = PROSPECTOR_TEMPLATE % (
+            'structlog', recipe.buildout_name, structlog_json_log)
+        prospectors.append(structlog_prospector)
+
+    # Create the filebeat config file
+    file_name = '%s.yml' % os.path.join(filebeat_dir, recipe.buildout_name)
+    filebeat_file = open(file_name, 'w')
+    filebeat_file.write('\n'.join(prospectors))
+    filebeat_file.close()
+    return file_name


### PR DESCRIPTION
This (unconditionally) creates filebeat prospector configs in `${buildout:etc-directory}/filebeat.d/deployment-name.yml` that pick up `ftw.structlog` and `ftw.contentstats` JSON logs.

I tested this config with a **filebeat > logstash** setup in a Linux VM and triggered forced **log rotation** (using the actual production logrotate configs, so `copytruncate` mode).

---

During these tests I noticed that when log events are produced with a high enough frequency (1/s), some events get missed by filebeat (requests actually got written to the `instance?-json.log` by Zope without gaps, so it's not the race condition inherent to "copytruncate" mode that's the problem).

Filebeat correctly notices that the file has been truncated, and starts reading it from the beginning again:
```
2017-11-30T16:29:44+01:00 INFO File was truncated. Begin reading file from offset 0: /home/zope/fb.local/02-filebeat.example.org/var/log/instance2-json.log
```

With lower event frequencies (1 event every 10s) this didn't happen (no skipped events).

I suspect filebeat's [backoff interval](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-filebeat-options.html#_literal_backoff_literal) is what's causing a race condition here:

- Once EOF is reached, filebeat only checks the file for new lines every $INTERVAL seconds
- $INTERVAL may be between 1-10 seconds (in the default config), depending on when the last new line was seen
- If the file has new events and gets truncated before filebeat has read them, events get lost

So in theory we should be able to minimize the chance of this race condition happening by tweaking the `*backoff*` settings in filebeat. But since logrotation happens during the night, I don't see this as an issue right now, so I'd recommend going with the defaults. Just something to be aware of.
