### PR TITLE
Fix FileExists error when a broken symlink exists

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.4.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix crash in buildout caused by broken symlinks. 
+  [Nachtalb]
 
 
 1.4.1 (2018-01-10)

--- a/ftw/recipe/deployment/pack.py
+++ b/ftw/recipe/deployment/pack.py
@@ -71,7 +71,7 @@ def create_pack_script(recipe):
                 pass
         if os.path.isdir(symlink_dir):
             link_path = os.path.join(symlink_dir, recipe.buildout_name)
-            if os.path.exists(link_path):
+            if os.path.lexists(link_path):
                 os.remove(link_path)
             os.symlink(script_path, link_path)
             created_files.append(link_path)


### PR DESCRIPTION
In the create_pack_script it used `os.path.exists` which returns false on broken symlinks. I changed it to `os.path.lexists`, which returns on True on broken symlinks. When the symlink was broken it thought there was no file and wanted to create a new symlink. This caused a FileExists error and the buildout crashed.