### PR TITLE
Skip duplicate zope parts when generating logrotate config

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,8 @@ Changelog
 1.4.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Skip duplicate zope parts when generating logrotate config.
+  [lgraf]
 
 
 1.4.2 (2019-02-04)


### PR DESCRIPTION
When extending from `ftw-buildouts` `zeoclients/n.cfg`, care must be taken to not extend from more than one of these cfgs. Otherwise, the respective instance parts will *all* be added, and you end up with duplicate instances in parts:

```python
['instance0', 'instance1', 'instance2', 'instance3', 'instance4', 'instance2', 'instance3', 'instance4', 'instance5', 'instance6', 'instance7', 'instance8']
```

Buildout itself apparently handles this (ignoring duplicates), but recipes will still see the full list, including duplicates.

This lead to a case where `ftw.recipe.deployment` created logrotate configs that contained duplicates, which the logrotate utility doesn't handle well.

We therefore
- **skip these duplicate parts** in order to not generate invalid logrotate configs
- but **log a warning** explaining the issue.