### PR TITLE
Add multi zeo support for packall script.

### DIFF
--- a/HISTORY.txt
+++ b/HISTORY.txt
@@ -4,7 +4,7 @@ Changelog
 1.4.4 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add multi zeo support for pack script generator. [mathias.leimgruber, Nachtalb]
 
 
 1.4.3 (2019-02-04)

--- a/ftw/recipe/deployment/pack.py
+++ b/ftw/recipe/deployment/pack.py
@@ -20,7 +20,8 @@ def create_pack_script(recipe):
             blob_storage = recipe.buildout[zeo_part].get(
                 'blob-storage', 'blobstorage')
             blob_storage = os.path.join(recipe.buildout_dir, 'var', blob_storage)
-        storages.append((file_storage, blob_storage))
+        zeopack_name = recipe.buildout[zeo_part].get('zeopack-script-name', 'zeopack')
+        storages.append((file_storage, blob_storage, zeopack_name))
 
     # Determine storages from c.r.filestorage parts
     for fs_part in recipe.filestorage_parts:
@@ -36,13 +37,17 @@ def create_pack_script(recipe):
                 if not blob_storage.startswith(os.path.sep):
                     blob_storage = os.path.join(
                         recipe.buildout['buildout']['directory'], blob_storage)
-            storages.append((file_storage, blob_storage))
+            zeopack_name = 'zeopack'
+            zeo_part_name = subpart_option(recipe.buildout, fs_part, 'zeo', 'zeo')
+            if zeo_part_name:
+                zeopack_name = recipe.buildout[zeo_part_name].get('zeopack-script-name', 'zeopack')
+            storages.append((file_storage, blob_storage, zeopack_name))
 
     # Create script
     created_files = []
     script = "#!/bin/sh\n"
-    zeopack = os.path.join(recipe.buildout_dir, 'bin', 'zeopack')
     for storage in storages:
+        zeopack = os.path.join(recipe.buildout_dir, 'bin', storage[2])
         if storage[1]:
             script += "%(zeopack)s -S %(file_storage)s -B %(blob_storage)s" % dict(
                 zeopack=zeopack, file_storage=storage[0], blob_storage=storage[1])

--- a/test-buildout-2.x.cfg
+++ b/test-buildout-2.x.cfg
@@ -7,3 +7,6 @@ extends =
 package-name = ftw.recipe.deployment
 jenkins_python = $PYTHON27
 
+
+[versions]
+setuptools = <45


### PR DESCRIPTION
This PR adds support for multiple zeo server within one buildout for the packall script.

plone.recipe.zeoserver already supports this by overriding the zeopack-script-name option, which results in having multiple pack scripts.